### PR TITLE
Unnecessary Creative Commons CoC box

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,4 +1,5 @@
-# Conributor Covenant Code of Conduct
+# Contributor Covenant Code of Conduct
+
 ## Our Pledge
 
 In the interest of fostering an open and welcoming environment, we as

--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,10 +1,4 @@
----
-name: "Code of Conduct"
-about: "The following Code of Conduct applies to all digital spaces managed by the Creative Commons engineering team, including GitHub, mailing lists, IRC and any other spaces which the development community uses for communication. Our Slack code of conduct is separate and <a href='https://wiki.creativecommons.org/wiki/Slack/Code_of_Conduct'>can be found here</a>."
-title: "CC Open Source Code of Conduct"
-source: "https://github.com/creativecommons/creativecommons.github.io-source/blob/master/content/community/code-of-conduct/contents.lr"
----
-
+# Conributor Covenant Code of Conduct
 ## Our Pledge
 
 In the interest of fostering an open and welcoming environment, we as


### PR DESCRIPTION
Changing Creative Commons CoC box to the actual top of the Contributor Covenant code of conduct.