### PR TITLE
doc(CONTRIBUTING.md): Fix the guidance on triggering validations

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -112,7 +112,7 @@ When in doubt, ask a question in the Discussions tab of the relevant repository.
     * If it's a new manifest, use `<app name>: Add version <version>`.
     * If it's an update to an existing manifest, use `<app name>@<version>: <small description>`.
     * If it's something related to maintenance, use `(chore): <small description>`.
-7. Add a comment starting with "/verify" after raising the PR - this will kick in the automatic manifest verifier.
+7. Manifest validations will be triggered automatically when a PR is created. If your changes fail one or more checks, please address the issues in the manifest and comment starting with `/verify` to rerun the checks.
 8. Wait for code review and address any issues raised as soon as you can.
 
 **A note on collaboration:** We encourage people to collaborate as much as possible. We especially appreciate contributors reviewing each others pull requests, as long as you are [kind and constructive](https://medium.com/@otarutunde/comments-during-code-reviews-2cb7791e1ac7) when you do so.


### PR DESCRIPTION
### Motivations
Since https://github.com/ScoopInstaller/GithubActions/pull/39  has been merged on **Feb 19, 2024**, manifest validations are now triggered automatically when a PR is created. The guidance in the contribution guide regarding how to trigger validations needs to be updated.

### Related PRs/Commits/Comments
- https://github.com/ScoopInstaller/GithubActions/pull/39
- https://github.com/ScoopInstaller/Main/commit/c1b0dbccd1f7f9a725a519e885d1a1d96ed7334e
- https://github.com/ScoopInstaller/Extras/commit/576cc06368edb2ab26808883d932ec61f91bcc53
- https://github.com/ScoopInstaller/Versions/commit/4b7ef69cb19cdc4f9240ac128a99ce83586223a1
- https://github.com/ScoopInstaller/.github/pull/6#discussion_r1008705128

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidelines to state manifest validations run automatically when a pull request is created.
  * Clarified follow-up steps: if validations fail, fix the issues and comment "/verify" to rerun the checks; wording standardized to reference "rerun the checks."
<!-- end of auto-generated comment: release notes by coderabbit.ai -->