### PR TITLE
doc(CONTRIBUTING.md): Fix the guidance on triggering validations

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -112,7 +112,7 @@ When in doubt, ask a question in the Discussions tab of the relevant repository.
     * If it's a new manifest, use `<app name>: Add version <version>`.
     * If it's an update to an existing manifest, use `<app name>@<version>: <small description>`.
     * If it's something related to maintenance, use `(chore): <small description>`.
-7. Manifest validations will be triggered automatically when a PR is created. If your changes fail one or more checks, please address the issues in the manifest and comment starting with `/verify` to rerun the checks.
+7. Add a comment starting with "/verify" after raising the PR - this will kick in the automatic manifest verifier.
 8. Wait for code review and address any issues raised as soon as you can.
 
 **A note on collaboration:** We encourage people to collaborate as much as possible. We especially appreciate contributors reviewing each others pull requests, as long as you are [kind and constructive](https://medium.com/@otarutunde/comments-during-code-reviews-2cb7791e1ac7) when you do so.


### PR DESCRIPTION
This reverts "doc(CONTRIBUTING.md): Fix the guidance on triggering validations (#24)".

Relates to https://github.com/ScoopInstaller/Main/commit/be035f2a7ae06a4a418ae58778aa0ee2fbcfe46d.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidelines for manifest verification workflow. Contributors are now required to comment with `/verify` after submitting a pull request to trigger the automatic manifest verification process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->